### PR TITLE
Fix pointer check in triangle_rpi4.c

### DIFF
--- a/triangle_rpi4.c
+++ b/triangle_rpi4.c
@@ -67,7 +67,7 @@ static int getDisplay(EGLDisplay *display)
     printf("resolution: %ix%i\n", mode.hdisplay, mode.vdisplay);
 
     drmModeEncoder *encoder = findEncoder(resources, connector);
-    if (connector == NULL)
+    if (encoder == NULL)
     {
         fprintf(stderr, "Unable to get encoder\n");
         drmModeFreeConnector(connector);


### PR DESCRIPTION
The existing code assigns `encoder`, but then checks if `connector == NULL`.